### PR TITLE
Fix null prefix

### DIFF
--- a/src/main/java/nstarlike/javautils/web/querystring/QueryStringBuilder.java
+++ b/src/main/java/nstarlike/javautils/web/querystring/QueryStringBuilder.java
@@ -69,7 +69,7 @@ public class QueryStringBuilder {
 	}
 	
 	public String buildQueryString(Map<String, String> params) {
-		return buildQueryString(params, null, null);
+		return buildQueryString(params, null, "");
 	}
 	
 	public String attachQueryString(Map<String, String> params) {


### PR DESCRIPTION
Modify null prefix to an empty string in the buildQueryString method of QueryStringBuilder