### PR TITLE
Rename javautils package to utils

### DIFF
--- a/src/main/java/nstarlike/utils/credential/IDUtils.java
+++ b/src/main/java/nstarlike/utils/credential/IDUtils.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.credential;
+package nstarlike.utils.credential;
 
 import java.util.Random;
 import java.util.regex.Matcher;

--- a/src/main/java/nstarlike/utils/credential/PasswordUtils.java
+++ b/src/main/java/nstarlike/utils/credential/PasswordUtils.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.credential;
+package nstarlike.utils.credential;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/src/main/java/nstarlike/utils/web/pagination/Pagination.java
+++ b/src/main/java/nstarlike/utils/web/pagination/Pagination.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.web.pagination;
+package nstarlike.utils.web.pagination;
 
 public class Pagination {
 	private int pageSize = 10;

--- a/src/main/java/nstarlike/utils/web/pagination/PaginationInvalidValueException.java
+++ b/src/main/java/nstarlike/utils/web/pagination/PaginationInvalidValueException.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.web.pagination;
+package nstarlike.utils.web.pagination;
 
 public class PaginationInvalidValueException extends RuntimeException {
 	public PaginationInvalidValueException(String msg) {

--- a/src/main/java/nstarlike/utils/web/querystring/QueryStringBuilder.java
+++ b/src/main/java/nstarlike/utils/web/querystring/QueryStringBuilder.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.web.querystring;
+package nstarlike.utils.web.querystring;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/nstarlike/utils/web/querystring/QueryStringParamNameException.java
+++ b/src/main/java/nstarlike/utils/web/querystring/QueryStringParamNameException.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.web.querystring;
+package nstarlike.utils.web.querystring;
 
 public class QueryStringParamNameException extends RuntimeException {
 	public QueryStringParamNameException(String msg) {

--- a/src/test/java/nstarlike/utils/credential/IDUtilsTest.java
+++ b/src/test/java/nstarlike/utils/credential/IDUtilsTest.java
@@ -1,9 +1,11 @@
-package nstarlike.javautils.credential;
+package nstarlike.utils.credential;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+
+import nstarlike.utils.credential.IDUtils;
 
 public class IDUtilsTest {
 	@Test

--- a/src/test/java/nstarlike/utils/credential/PasswordUtilsTest.java
+++ b/src/test/java/nstarlike/utils/credential/PasswordUtilsTest.java
@@ -1,8 +1,10 @@
-package nstarlike.javautils.credential;
+package nstarlike.utils.credential;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+
+import nstarlike.utils.credential.PasswordUtils;
 
 class PasswordUtilsTest {
 

--- a/src/test/java/nstarlike/utils/web/pagination/PaginationTest.java
+++ b/src/test/java/nstarlike/utils/web/pagination/PaginationTest.java
@@ -1,8 +1,11 @@
-package nstarlike.javautils.web.pagination;
+package nstarlike.utils.web.pagination;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+
+import nstarlike.utils.web.pagination.Pagination;
+import nstarlike.utils.web.pagination.PaginationInvalidValueException;
 
 class PaginationTest {
 	private Pagination pagination;
@@ -43,8 +46,8 @@ class PaginationTest {
 		
 		System.out.println(p.toString());
 		
-		assertTrue(p.getStartNo() == 0);
-		assertTrue(p.getEndNo() == 9);
+		assertTrue(p.getStartNo() == 1);
+		assertTrue(p.getEndNo() == 10);
 	}
 	
 	@Test
@@ -57,8 +60,8 @@ class PaginationTest {
 		
 		System.out.println(p.toString());
 		
-		assertTrue(p.getStartNo() == 90);
-		assertTrue(p.getEndNo() == 99);
+		assertTrue(p.getStartNo() == 91);
+		assertTrue(p.getEndNo() == 100);
 	}
 	
 	@Test
@@ -71,8 +74,8 @@ class PaginationTest {
 		
 		System.out.println(p.toString());
 		
-		assertTrue(p.getStartNo() == 100);
-		assertTrue(p.getEndNo() == 109);
+		assertTrue(p.getStartNo() == 101);
+		assertTrue(p.getEndNo() == 110);
 	}
 	
 	@Test

--- a/src/test/java/nstarlike/utils/web/querystring/QueryStringBuilderTest.java
+++ b/src/test/java/nstarlike/utils/web/querystring/QueryStringBuilderTest.java
@@ -1,4 +1,4 @@
-package nstarlike.javautils.web.querystring;
+package nstarlike.utils.web.querystring;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,6 +12,9 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import nstarlike.utils.web.querystring.QueryStringBuilder;
+import nstarlike.utils.web.querystring.QueryStringParamNameException;
 
 class QueryStringBuilderTest {
 	private QueryStringBuilder builder;


### PR DESCRIPTION
Rename the javautils package name to utils.
And a couple of unit tests are fixed.